### PR TITLE
[Agent: Q仔] 兼容中文冒号 + qzai-workflows 自测启用

### DIFF
--- a/.github/workflows/qzai-issue-commands-wrapper.yml
+++ b/.github/workflows/qzai-issue-commands-wrapper.yml
@@ -1,0 +1,14 @@
+name: QZAI Issue Commands (This Repo)
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  qzai-issue-commands:
+    uses: ./.github/workflows/qzai-issue-commands.yml
+    secrets: inherit

--- a/.github/workflows/qzai-issue-commands.yml
+++ b/.github/workflows/qzai-issue-commands.yml
@@ -49,10 +49,10 @@ jobs:
             const validStatus = new Set(['todo', 'in-progress', 'blocked', 'review', 'done']);
             const commandRegex = /\/qzai\s+(decision|next|status|ship)\b/g;
             const blockFor = (name) => {
-              const re = new RegExp(String.raw`\/qzai\s+${name}:\s*([\s\S]*?)(?=\n\s*\/qzai\s+(?:decision|next|status|ship)\b|$)`, 'ig');
+              const re = new RegExp(String.raw`\/qzai\s+${name}[:：]\s*([\s\S]*?)(?=\n\s*\/qzai\s+(?:decision|next|status|ship)\b|$)`, 'ig');
               return [...body.matchAll(re)].map((m) => (m[1] || '').trim()).filter(Boolean);
             };
-            const statusMatches = [...body.matchAll(/\/qzai\s+status:\s*([^\n\r]+)/ig)]
+            const statusMatches = [...body.matchAll(/\/qzai\s+status[:：]\s*([^\n\r]+)/ig)]
               .map((m) => (m[1] || '').trim().toLowerCase())
               .filter(Boolean);
             const hasShip = /(^|\n)\s*\/qzai\s+ship\s*($|\n)/im.test(body);

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -43,9 +43,9 @@ jobs:
 
 ## 支持命令
 
-- `/qzai status: <todo|in-progress|blocked|review|done>`
-- `/qzai decision: ...`
-- `/qzai next: ...`
+- `/qzai status[:：] <todo|in-progress|blocked|review|done>`
+- `/qzai decision[:：] ...`
+- `/qzai next[:：] ...`
 - `/qzai ship`
 
 行为与 `voice-insight` 的现有版本一致：中文输出、真实换行、`status:*` 标签自动管理且会确保目标标签存在。


### PR DESCRIPTION
## 做了什么

- 指令解析兼容中文冒号 `：`（同时兼容 `:`）
- 在 qzai-workflows 仓库内新增 wrapper workflow，使本仓库 issue 评论也能触发 `/qzai ...`（dogfooding）
- 更新 docs/USAGE.md 说明 `[:：]` 写法

## 为什么

- 避免用户输入全角冒号导致无反应
- 让基础设施仓库自身也能用指令推进，便于迭代

**【Agent: Q仔】**