### PR TITLE
[Agent: Q仔] 固化 Issue/PR 生命周期与 PR 模板

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,12 @@
 
 ## 关联 Issue（必填）
 
-- Refs #<issue-number>（计划类 PR）
-- Closes #<issue-number>（实现类 PR，合并后自动关闭）
+规则：二选一（默认不要同时写）
+- 计划类 PR：Refs #<issue-number>
+- 实现类 PR：Closes #<issue-number>（合并后自动关闭）
+
+- Refs #<issue-number>
+- Closes #<issue-number>
 
 ## 做了什么
 
@@ -17,6 +21,7 @@
 - [ ] 关键逻辑有验证证据（见下方“测试与验证”）
 - [ ] 文档/注释已同步（如需要）
 - [ ] 风险与回滚已说明
+- [ ] 如使用 Projects 看板：已同步 Project 字段（Status/Priority 等）
 
 ## 测试与验证
 

--- a/docs/LIFECYCLE.md
+++ b/docs/LIFECYCLE.md
@@ -47,6 +47,18 @@
 
 ---
 
+## 看板（Projects）联动（最小约定）
+
+原则：**Issue 是真相源（SSOT），看板只是投影**。
+
+- `status:*`、`priority:*` **一律用 Issue label 表达**（例如 `status:todo`、`status:review`、`priority:P0`）。
+- Projects 作为可视化：
+  - Project 字段 `Status` 建议与 `status:*` 同步（Todo/In Progress/Blocked/Review/Done）。
+  - Project 字段 `Priority` 建议与 `priority:*` 同步。
+
+当前阶段：我们先以 label 作为唯一驱动源；Project 同步能力后续由 `/qzai` 自动化补齐。
+
+
 ## 强制规则（不满足即不合并）
 
 1) **每个 PR 必须关联至少一个 Issue**
@@ -76,3 +88,21 @@
 - Closes #123
 
 说明：合并后会自动关闭 #123。
+
+---
+
+## Plan PR 边界（什么算“只写计划”）
+
+允许：
+- 新增/修改文档（计划、SOP、说明）
+- 新增 Issue 拆解清单（以文档或 issue 列表形式）
+
+不允许（除非 Master 明确要求）：
+- 引入实际业务代码变更
+- 大规模重构
+
+## 最小实例
+
+- Issue #123：明确目标与 DoD
+- Plan PR #124：`Refs #123`，只提交计划文档
+- Impl PR #125：`Closes #123`，提交实现与测试证据

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -47,6 +47,8 @@ jobs:
 
 该文档定义了 Issue 与 PR 的职责边界与推荐流转图：默认 **先有 Issue，再有 PR**，并由实现 PR 使用 `Closes #<issue>` 关闭 Issue。
 
+看板（Projects）方面：当前以 Issue label（`status:*`/`priority:*`）作为唯一驱动源；Projects 作为投影，后续由 `/qzai` 自动化补齐同步能力。
+
 ## 支持命令
 
 - `/qzai status[:：] <todo|in-progress|blocked|review|done>`


### PR DESCRIPTION
## 做了什么

- 新增 docs/LIFECYCLE.md：明确 Issue/PR 职责边界与两条流转图（推荐/例外）
- 新增 PR 模板：.github/pull_request_template.md（强制 Refs/Closes、测试、风险回滚、署名）
- docs/USAGE.md 增加“推荐流程”入口

## 目的

让团队用同一套流程推进：Issue 管事，PR 管改动；PR 必须关联 Issue，合并后关闭。

**【Agent: Q仔】**