### PR TITLE
[Agent: 冷燕] fix: botLogin 动态识别 + /qzai next 多行幂等

### DIFF
--- a/.github/workflows/qzai-issue-commands.yml
+++ b/.github/workflows/qzai-issue-commands.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
+            const crypto = require('crypto');
+
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const issueNumber = context.payload.issue.number;
@@ -46,7 +48,10 @@ jobs:
               return;
             }
 
-            const botLogin = 'qzai-bot[bot]';
+
+            // 动态获取当前 token 对应的 login（避免写死 qzai-bot[bot]）
+            const { data: me } = await github.rest.users.getAuthenticated();
+            const botLogin = me.login;
 
             const safeCreateReaction = async (content) => {
               try {
@@ -109,11 +114,10 @@ jobs:
                 (r) => r.content === 'rocket' && r.user && r.user.login === botLogin
               );
               if (alreadyDone) {
-                core.info('Skip: comment already processed successfully by qzai-bot (rocket reaction found).');
-                return;
+                core.info(`Note: rocket reaction by ${botLogin} exists; continue to allow /qzai next multi-item idempotency.`);
               }
 
-              // 并发窗口收敛：只认 qzai-bot[bot] 的 👀（eyes）作为“处理中”锁。
+              // 并发窗口收敛：只认当前 botLogin 的 👀（eyes）作为“处理中”锁。
               const botEyesReaction = reactions.find(
                 (r) => r.content === 'eyes' && r.user && r.user.login === botLogin
               );
@@ -272,11 +276,13 @@ jobs:
 
                 const links = [];
                 for (const title of items) {
-                  const issueBodyContent = `Parent: #${issueNumber}\\nSource comment: ${comment.html_url}\\nRequested by: @${actor}`;
+                  const normalizedTitle = title.replace(/\\s+/g, ' ').trim();
+                  const itemKey = crypto.createHash('sha256').update(normalizedTitle).digest('hex');
+                  const issueBodyContent = `Parent: #${issueNumber}\\nSource comment: ${comment.html_url}\\nItem key: ${itemKey}\\nRequested by: @${actor}`;
 
-                  // 检查是否已存在包含相同 Source comment URL 的 Issue
+                  // 检查是否已存在相同 comment_url + itemKey 的 Issue（多行幂等）
                   const searchResult = await github.rest.search.issuesAndPullRequests({
-                    q: `repo:${owner}/${repo} in:body "Source comment: ${comment.html_url}"`, // Corrected escaping for double quotes
+                    q: `repo:${owner}/${repo} in:body "Source comment: ${comment.html_url}" "Item key: ${itemKey}"`,
                     per_page: 1, // 只需检查是否存在一个
                   });
 


### PR DESCRIPTION
## 修复内容（P0）

1. botLogin 不再写死为 qzai-bot[bot]：改为 `github.rest.users.getAuthenticated()` 动态获取当前 token 的 login。
2. /qzai next 升级为 item 级幂等：对每行 title 计算 `itemKey = sha256(normalizedTitle)`；Issue body 写入 `Item key: <itemKey>`；search 去重同时匹配 comment_url + itemKey，保证同一 comment 多行 next 可创建多个 issue，重复运行不会重复创建。
3. 不再因 comment 上已有 rocket 回执而整体 short-circuit（否则编辑评论追加 next 会被误跳过）。

## 验证方式（静态）

- grep 确认不存在硬编码：`const botLogin = 'qzai-bot[bot]'`
- grep 确认包含：`users.getAuthenticated()`、`Item key:`、search query 同时包含 comment_url + itemKey

## 风险

- 仍依赖 GitHub Search 延迟；但幂等键粒度更细，误判概率显著降低。
