### PR TITLE
[Q仔] GitHub App 写入统一 + #hq 进度通知

### DIFF
--- a/.github/workflows/qzai-impl-auto-trigger.yml
+++ b/.github/workflows/qzai-impl-auto-trigger.yml
@@ -14,10 +14,27 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Slack notify start
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow started: ${GITHUB_WORKFLOW}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\nrun: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.QZAI_APP_ID }}
+          private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}
+
       - name: Check if merged PR is a Plan PR and auto-trigger implement
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -38,3 +55,15 @@ jobs:
               issue_number: prNumber,
               body: `/qzai implement\nautoTriggered: true\ntriggerReason: plan-pr-merged`,
             });
+
+      - name: Slack notify end
+        if: ${{ always() && secrets.SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow finished: ${GITHUB_WORKFLOW}\\nstatus: ${JOB_STATUS}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\nrun: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}

--- a/.github/workflows/qzai-impl-auto-trigger.yml
+++ b/.github/workflows/qzai-impl-auto-trigger.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Slack notify start
         if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -26,7 +27,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ secrets.QZAI_APP_ID }}
           private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-issue-close.yml
+++ b/.github/workflows/qzai-issue-close.yml
@@ -14,10 +14,27 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Slack notify start
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow started: ${GITHUB_WORKFLOW}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\nrun: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.QZAI_APP_ID }}
+          private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}
+
       - name: Update linked Issue status to done after Impl PR merge
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -65,3 +82,16 @@ jobs:
                 core.warning(`Failed to update Issue #${issueNumber}: ${e.message}`);
               }
             }
+
+      - name: Slack notify end
+        if: ${{ always() && secrets.SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow finished: ${GITHUB_WORKFLOW}\\nstatus: ${JOB_STATUS}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\nrun: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}
+

--- a/.github/workflows/qzai-issue-close.yml
+++ b/.github/workflows/qzai-issue-close.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - name: Slack notify start
         if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -26,7 +27,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ secrets.QZAI_APP_ID }}
           private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-issue-commands-wrapper.yml
+++ b/.github/workflows/qzai-issue-commands-wrapper.yml
@@ -15,6 +15,19 @@ jobs:
     outputs:
       allow_wrapper: ${{ steps.check.outputs.allow_wrapper }}
     steps:
+      - name: Slack notify start
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_url="${{ github.event.comment.html_url }}"
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow started: ${GITHUB_WORKFLOW}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\ncomment: ${comment_url}\\nrun: ${run_url}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
       - id: check
         name: Check first-line command
         shell: bash
@@ -41,3 +54,22 @@ jobs:
     if: ${{ needs.guard-two-stage-overlap.outputs.allow_wrapper == 'true' }}
     uses: ./.github/workflows/qzai-issue-commands.yml
     secrets: inherit
+
+  slack-notify-end:
+    needs: [guard-two-stage-overlap, qzai-issue-commands]
+    if: ${{ always() && secrets.SLACK_WEBHOOK_URL != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack notify end
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_url="${{ github.event.comment.html_url }}"
+          # prefer the real result of the called workflow if it ran, otherwise use guard result
+          result="${{ needs.qzai-issue-commands.result || needs.guard-two-stage-overlap.result }}"
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow finished: ${GITHUB_WORKFLOW}\\nresult: ${result}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\ncomment: ${comment_url}\\nrun: ${run_url}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/qzai-issue-commands-wrapper.yml
+++ b/.github/workflows/qzai-issue-commands-wrapper.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - name: Slack notify start
         if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/qzai-issue-commands.yml
+++ b/.github/workflows/qzai-issue-commands.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Create GitHub App installation token
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ secrets.QZAI_APP_ID }}
           private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-plan-auto-trigger.yml
+++ b/.github/workflows/qzai-plan-auto-trigger.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - name: Slack notify start
         if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -25,7 +26,7 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
       - id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ secrets.QZAI_APP_ID }}
           private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-plan-auto-trigger.yml
+++ b/.github/workflows/qzai-plan-auto-trigger.yml
@@ -13,10 +13,27 @@ jobs:
     if: github.event.label.name == 'type:feat'
     runs-on: ubuntu-latest
     steps:
+      - name: Slack notify start
+        if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow started: ${GITHUB_WORKFLOW}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\nrun: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      - id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.QZAI_APP_ID }}
+          private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}
+
       - name: Auto-trigger /qzai plan
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -38,3 +55,15 @@ jobs:
               issue_number: issueNumber,
               body: `/qzai plan\nautoTriggered: true\ntriggerReason: type:feat-label-added`,
             });
+
+      - name: Slack notify end
+        if: ${{ always() && secrets.SLACK_WEBHOOK_URL != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow finished: ${GITHUB_WORKFLOW}\\nstatus: ${JOB_STATUS}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\nrun: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          JOB_STATUS: ${{ job.status }}

--- a/.github/workflows/qzai-pr-review-wrapper.yml
+++ b/.github/workflows/qzai-pr-review-wrapper.yml
@@ -11,7 +11,41 @@ permissions:
   checks: write
 
 jobs:
+  slack-notify-start:
+    if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack notify start
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_url="${{ github.event.comment.html_url }}"
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow started: ${GITHUB_WORKFLOW}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\ncomment: ${comment_url}\\nrun: ${run_url}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   call-review-flow:
     if: github.event.issue.pull_request != null
     uses: ./.github/workflows/qzai-pr-review.yml
     secrets: inherit
+
+  slack-notify-end:
+    needs: [call-review-flow]
+    if: ${{ always() && secrets.SLACK_WEBHOOK_URL != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack notify end
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_url="${{ github.event.comment.html_url }}"
+          result="${{ needs.call-review-flow.result }}"
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow finished: ${GITHUB_WORKFLOW}\\nresult: ${result}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\ncomment: ${comment_url}\\nrun: ${run_url}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/qzai-pr-review.yml
+++ b/.github/workflows/qzai-pr-review.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Create GitHub App installation token
         if: steps.cmd.outputs.skip != '1'
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ steps.sel.outputs.app_id }}
           private_key: ${{ env.APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-pr-slash-review.yml
+++ b/.github/workflows/qzai-pr-slash-review.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Create GitHub App installation token
         if: steps.cmd.outputs.skip != '1'
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ steps.sel.outputs.app_id }}
           private_key: ${{ env.APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-review-auto-first.yml
+++ b/.github/workflows/qzai-review-auto-first.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ secrets.QZAI_APP_ID }}
           private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-review-auto-first.yml
+++ b/.github/workflows/qzai-review-auto-first.yml
@@ -17,10 +17,16 @@ jobs:
   auto-first-review:
     runs-on: ubuntu-latest
     steps:
+      - id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.QZAI_APP_ID }}
+          private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}
+
       - name: Trigger first review on Impl PR
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/qzai-review-loop.yml
+++ b/.github/workflows/qzai-review-loop.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ secrets.QZAI_APP_ID }}
           private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}

--- a/.github/workflows/qzai-review-loop.yml
+++ b/.github/workflows/qzai-review-loop.yml
@@ -17,10 +17,16 @@ jobs:
   check-and-trigger:
     runs-on: ubuntu-latest
     steps:
+      - id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.QZAI_APP_ID }}
+          private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}
+
       - name: Check review_rounds status and auto-trigger next review
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/qzai-slash-bridge-v1.yml
+++ b/.github/workflows/qzai-slash-bridge-v1.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ secrets.QZAI_APP_ID }}
           private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}
@@ -184,15 +184,15 @@ jobs:
           for i in range(3):
               try:
                   with urllib.request.urlopen(req, timeout=8) as resp:
-            out = resp.read().decode('utf-8')
-            print(out)
-            break
+                      out = resp.read().decode('utf-8')
+                      print(out)
+                      break
               except Exception as e:
                   last_err = e
                   time.sleep(0.8*(2**i))
           else:
               raise SystemExit(f"HOOK_POST_FAILED: {last_err}")
-          PY
+PY
 
       - name: Write failure comment/check-run (fail-closed)
         if: failure() && steps.parse.outputs.skip != '1'

--- a/.github/workflows/qzai-slash-bridge-v1.yml
+++ b/.github/workflows/qzai-slash-bridge-v1.yml
@@ -19,6 +19,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - id: app-token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.QZAI_APP_ID }}
+          private_key: ${{ secrets.QZAI_APP_PRIVATE_KEY }}
+
       - name: Parse /qzai command (first line)
         id: parse
         uses: actions/github-script@v7
@@ -54,7 +60,7 @@ jobs:
         id: ctx
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -113,86 +119,86 @@ jobs:
           fi
 
           python3 - <<'PY'
-import json, os, time, secrets, hmac, hashlib, urllib.request
-
-hook_base = os.environ['HOOK_BASE_URL'].rstrip('/')
-url = hook_base + '/hooks/slash-bridge-v1'
-secret = os.environ['HOOK_SECRET'].encode()
-
-command = os.environ['COMMAND']
-args = os.environ.get('ARGS','')
-agent_id = os.environ.get('AGENT_ID','').strip()
-repo = f"{os.environ['OWNER']}/{os.environ['REPO']}"
-
-issue_number = int(os.environ['ISSUE_NUMBER'])
-comment_id = int(os.environ['COMMENT_ID'])
-comment_url = os.environ['COMMENT_URL']
-requested_by = os.environ['REQUESTED_BY']
-requested_at = os.environ['REQUESTED_AT']
-head_sha = os.environ.get('HEAD_SHA','')
-base_sha = os.environ.get('BASE_SHA','')
-
-trace_id = 'trc_' + secrets.token_hex(12)
-run_id = 'run_' + secrets.token_hex(12)
-
-args_hash = hashlib.sha256(args.encode()).hexdigest()
-idempotency_key = f"{repo}#{issue_number}#{head_sha}#{command}#{args_hash}#{requested_by}#{comment_id}"
-
-payload = {
-  'schemaVersion': 1,
-  # Actions cannot access X-GitHub-Delivery; use commentId as deterministic surrogate for v1.
-  'deliveryId': str(comment_id),
-  'traceId': trace_id,
-  'runId': run_id,
-  'command': command,
-  'args': args,
-  'agentId': agent_id,
-  'repo': repo,
-  'installationId': int(os.environ['INSTALLATION_ID']),
-  'issueNumber': issue_number,
-  'prNumber': issue_number,
-  'commentId': comment_id,
-  'commentUrl': comment_url,
-  'headSha': head_sha,
-  'baseSha': base_sha,
-  'requestedBy': requested_by,
-  'requestedAt': requested_at,
-  'authorAssociation': os.environ.get('AUTHOR_ASSOCIATION',''),
-  'idempotencyKey': idempotency_key,
-}
-
-body = json.dumps(payload, separators=(',',':')).encode()
-nonce = secrets.token_hex(16)
-ts = int(time.time()*1000)
-mac = hmac.new(secret, body, hashlib.sha256).hexdigest()
-
-req = urllib.request.Request(url, data=body, method='POST')
-req.add_header('Content-Type', 'application/json')
-req.add_header('User-Agent', 'curl/8.0')
-req.add_header('X-Hub-Signature-256', 'sha256=' + mac)
-req.add_header('X-QZAI-Timestamp', str(ts))
-req.add_header('X-QZAI-Nonce', nonce)
-
-# HTTP timeout+retry (fail-closed)
-last_err = None
-for i in range(3):
-    try:
-        with urllib.request.urlopen(req, timeout=8) as resp:
+          import json, os, time, secrets, hmac, hashlib, urllib.request
+          
+          hook_base = os.environ['HOOK_BASE_URL'].rstrip('/')
+          url = hook_base + '/hooks/slash-bridge-v1'
+          secret = os.environ['HOOK_SECRET'].encode()
+          
+          command = os.environ['COMMAND']
+          args = os.environ.get('ARGS','')
+          agent_id = os.environ.get('AGENT_ID','').strip()
+          repo = f"{os.environ['OWNER']}/{os.environ['REPO']}"
+          
+          issue_number = int(os.environ['ISSUE_NUMBER'])
+          comment_id = int(os.environ['COMMENT_ID'])
+          comment_url = os.environ['COMMENT_URL']
+          requested_by = os.environ['REQUESTED_BY']
+          requested_at = os.environ['REQUESTED_AT']
+          head_sha = os.environ.get('HEAD_SHA','')
+          base_sha = os.environ.get('BASE_SHA','')
+          
+          trace_id = 'trc_' + secrets.token_hex(12)
+          run_id = 'run_' + secrets.token_hex(12)
+          
+          args_hash = hashlib.sha256(args.encode()).hexdigest()
+          idempotency_key = f"{repo}#{issue_number}#{head_sha}#{command}#{args_hash}#{requested_by}#{comment_id}"
+          
+          payload = {
+            'schemaVersion': 1,
+            # Actions cannot access X-GitHub-Delivery; use commentId as deterministic surrogate for v1.
+            'deliveryId': str(comment_id),
+            'traceId': trace_id,
+            'runId': run_id,
+            'command': command,
+            'args': args,
+            'agentId': agent_id,
+            'repo': repo,
+            'installationId': int(os.environ['INSTALLATION_ID']),
+            'issueNumber': issue_number,
+            'prNumber': issue_number,
+            'commentId': comment_id,
+            'commentUrl': comment_url,
+            'headSha': head_sha,
+            'baseSha': base_sha,
+            'requestedBy': requested_by,
+            'requestedAt': requested_at,
+            'authorAssociation': os.environ.get('AUTHOR_ASSOCIATION',''),
+            'idempotencyKey': idempotency_key,
+          }
+          
+          body = json.dumps(payload, separators=(',',':')).encode()
+          nonce = secrets.token_hex(16)
+          ts = int(time.time()*1000)
+          mac = hmac.new(secret, body, hashlib.sha256).hexdigest()
+          
+          req = urllib.request.Request(url, data=body, method='POST')
+          req.add_header('Content-Type', 'application/json')
+          req.add_header('User-Agent', 'curl/8.0')
+          req.add_header('X-Hub-Signature-256', 'sha256=' + mac)
+          req.add_header('X-QZAI-Timestamp', str(ts))
+          req.add_header('X-QZAI-Nonce', nonce)
+          
+          # HTTP timeout+retry (fail-closed)
+          last_err = None
+          for i in range(3):
+              try:
+                  with urllib.request.urlopen(req, timeout=8) as resp:
             out = resp.read().decode('utf-8')
             print(out)
             break
-    except Exception as e:
-        last_err = e
-        time.sleep(0.8*(2**i))
-else:
-    raise SystemExit(f"HOOK_POST_FAILED: {last_err}")
-PY
+              except Exception as e:
+                  last_err = e
+                  time.sleep(0.8*(2**i))
+          else:
+              raise SystemExit(f"HOOK_POST_FAILED: {last_err}")
+          PY
 
       - name: Write failure comment/check-run (fail-closed)
         if: failure() && steps.parse.outputs.skip != '1'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ github.token }}
+          github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;

--- a/.github/workflows/qzai-two-stage-pr-wrapper.yml
+++ b/.github/workflows/qzai-two-stage-pr-wrapper.yml
@@ -11,6 +11,40 @@ permissions:
   checks: write
 
 jobs:
+  slack-notify-start:
+    if: ${{ secrets.SLACK_WEBHOOK_URL != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack notify start
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_url="${{ github.event.comment.html_url }}"
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow started: ${GITHUB_WORKFLOW}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\ncomment: ${comment_url}\\nrun: ${run_url}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
   qzai-two-stage:
     uses: ./.github/workflows/qzai-two-stage-pr.yml
     secrets: inherit
+
+  slack-notify-end:
+    needs: [qzai-two-stage]
+    if: ${{ always() && secrets.SLACK_WEBHOOK_URL != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack notify end
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          comment_url="${{ github.event.comment.html_url }}"
+          result="${{ needs.qzai-two-stage.result }}"
+          curl -sS -X POST "$SLACK_WEBHOOK_URL" \
+            -H 'Content-type: application/json' \
+            --data "{\"text\":\"[QZAI] workflow finished: ${GITHUB_WORKFLOW}\\nresult: ${result}\\nrepo: ${GITHUB_REPOSITORY}\\nactor: ${GITHUB_ACTOR}\\ncomment: ${comment_url}\\nrun: ${run_url}\"}"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/qzai-two-stage-pr.yml
+++ b/.github/workflows/qzai-two-stage-pr.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Create GitHub App installation token
         if: steps.cmd.outputs.skip != '1'
         id: app-token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3065cf300ef59631528306a1bcec6a18b7752881 # v2
         with:
           app_id: ${{ steps.sel.outputs.app_id }}
           private_key: ${{ env.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## 目标\n1) 所有自动写入（评论/打标签/更新状态/失败回写）统一使用 GitHub App installation token（tibdex/github-app-token@v2），避免出现 github-actions[bot]/个人身份。\n2) /qzai 入口 wrapper 与自动触发流程增加 #hq Slack 通知（开始/结束），用于可视化进度。\n\n## 变更点\n- auto-trigger/auto-close/review loop：新增 app-token step，并把 github-script 写入 token 切到 app token。\n- wrapper workflows：增加 start/end 两段 Slack webhook 通知（若未配置 secrets.SLACK_WEBHOOK_URL 自动跳过）。\n- slash-bridge-v1：失败回写（comment + check-run）改用 app token。\n\n## 你需要做的配置\n- repo secrets：QZAI_APP_ID / QZAI_APP_PRIVATE_KEY\n- repo secret：SLACK_WEBHOOK_URL（指向 #hq 的 incoming webhook）\n\n## 验收\n- GitHub 写入 actor 显示为 GitHub App\n- 触发 /qzai 或自动触发后，#hq 能看到 started/finished 两条通知（含 run 链接）\n